### PR TITLE
Small changed in multi-review support

### DIFF
--- a/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
@@ -165,7 +165,10 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 first_review_repre = False
             else:
                 # Add representation name to asset name of "not first" review
-                review_item["asset_data"]["name"] += repre["name"].title()
+                asset_name = review_item["asset_data"]["name"]
+                review_item["asset_data"]["name"] = "_".join(
+                    (asset_name, repre["name"])
+                )
 
             # Set location
             review_item["component_location"] = ftrack_server_location

--- a/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
@@ -160,9 +160,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
                 }
             }
             # Create copy of item before setting location or changing asset
-            src_components_to_add.append(
-                (repre, copy.deepcopy(review_item))
-            )
+            src_components_to_add.append(copy.deepcopy(review_item))
             if first_review_repre:
                 first_review_repre = False
             else:
@@ -196,16 +194,14 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             }
             thumbnail_item["thumbnail"] = True
             # Create copy of item before setting location
-            src_components_to_add.append(
-                (repre, copy.deepcopy(thumbnail_item))
-            )
+            src_components_to_add.append(copy.deepcopy(review_item))
             # Set location
             thumbnail_item["component_location"] = ftrack_server_location
             # Add item to component list
             component_list.append(thumbnail_item)
 
         # Add source components for review and thubmnail components
-        for repre, copy_src_item in src_components_to_add:
+        for copy_src_item in src_components_to_add:
             # Make sure thumbnail is disabled
             copy_src_item["thumbnail"] = False
             # Set location

--- a/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
@@ -178,16 +178,20 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
         # Create thumbnail components
         # TODO what if there is multiple thumbnails?
         for repre in thumbnail_representations:
-            if not repre.get("published_path"):
+            published_path = repre.get("published_path")
+            if not published_path:
                 comp_files = repre["files"]
                 if isinstance(comp_files, (tuple, list, set)):
                     filename = comp_files[0]
                 else:
                     filename = comp_files
 
-                repre["published_path"] = os.path.join(
+                published_path = os.path.join(
                     repre["stagingDir"], filename
                 )
+                if not os.path.exists(published_path):
+                    continue
+                repre["published_path"] = published_path
 
             # Create copy of base comp item and append it
             thumbnail_item = copy.deepcopy(base_component_item)
@@ -197,7 +201,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             }
             thumbnail_item["thumbnail"] = True
             # Create copy of item before setting location
-            src_components_to_add.append(copy.deepcopy(review_item))
+            src_components_to_add.append(copy.deepcopy(thumbnail_item))
             # Set location
             thumbnail_item["component_location"] = ftrack_server_location
             # Add item to component list
@@ -217,12 +221,16 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
 
         # Add others representations as component
         for repre in other_representations:
+            published_path = repre.get("published_path")
+            if not published_path:
+                continue
             # Create copy of base comp item and append it
             other_item = copy.deepcopy(base_component_item)
             other_item["component_data"] = {
                 "name": repre["name"]
             }
             other_item["component_location"] = unmanaged_location
+            other_item["component_path"] = published_path
             component_list.append(other_item)
 
         def json_obj_parser(obj):

--- a/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
+++ b/pype/plugins/ftrack/publish/integrate_ftrack_instances.py
@@ -105,7 +105,7 @@ class IntegrateFtrackInstance(pyblish.api.InstancePlugin):
             if repre.get("thumbnail") or "thumbnail" in repre_tags:
                 thumbnail_representations.append(repre)
 
-            elif "ftrackreview" in repre_tags:
+            elif repre.get("ftrackreview") or "ftrackreview" in repre_tags:
                 review_representations.append(repre)
 
             else:


### PR DESCRIPTION
## Changes
- rewriten plugin to easier handle multiple review representations
- first review component does not change ftrack asset name
    - all following review representations will create ftrack asset name with contatenation of subset name and representation name